### PR TITLE
Added .editorconfig for coding style consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+#C# Naming Conventions
+dotnet_naming_rule.methods_and_properties.pascal_case.symbols = method, property
+dotnet_naming_rule.methods_and_properties.pascal_case.style = pascal_case
+dotnet_naming_rule.local_variables.camel_case.symbols = local
+dotnet_naming_rule.local_variables.camel_case.style = camel_case
+
+
+# Enforce "using" directives to be placed at the top of the file
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_require_accessibility_modifiers = always:suggestion
+
+# Force braces around if/else/for/while blocks
+csharp_prefer_braces = true:suggestion
+
+# Place "this." before instance members
+dotnet_style_qualification_for_property = true:suggestion
+dotnet_style_qualification_for_method = false:suggestion

--- a/AIMS/Program.cs
+++ b/AIMS/Program.cs
@@ -27,3 +27,5 @@ app.MapControllerRoute(
 
 
 app.Run();
+
+

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,0 +1,25 @@
+# Coding Style Guide (`.editorconfig`)
+
+## What is `.editorconfig`?
+
+This `.editorconfig` file enforces a **consistent coding style** across the team by:
+
+- **Using 4 spaces for indentation** (no tabs).
+- **Enforcing PascalCase for methods & properties**.
+- **Using camelCase for local variables**.
+- **Requiring braces `{}` around all if/else/for/while blocks**.
+- **Removing trailing whitespace automatically**.
+- **Ensuring all files end with a newline**.
+
+## How to Enable Auto-Formatting
+
+### **🔹 VS Code**
+
+1. Open **VS Code**.
+2. Go to **Settings \***.
+3. Search for **"Format on Save"** and **enable it**.
+
+### **🔹 Visual Studio**
+
+1. Go to **Tools → Options → Text Editor → C# → Code Style**.
+2. Ensure **"Format document on save"** is enabled.


### PR DESCRIPTION
**Purpose**
- Keeps code consistent across all developers
- Prevents style-related merge conflicts
- Improves code readability & maintainability

 **.editorconfig Now Enforces**
- Indentation & Spacing – Uses 4 spaces per indent, trims trailing whitespace, and ensures newlines at the end of files.
- Naming Conventions – PascalCase for methods & properties, camelCase for variables (best practices in C#).

 **Code Structure Rules**

- Forces braces {} on if/else/for/while -> Avoids risky single-line statements.
- Ensures using directives are at the top -> Keeps imports organized.
- Requires explicit public/private access modifiers -> Prevents implicit access levels.
 - Encourages this. for instance properties -> Improves readability in larger codebases.
 
 **Coding Style followed with Official .NET Common C# code conventions document**
