### PR TITLE
Scaffolded EF Core models for Hardware and Software tables with AimsDbContext 

### DIFF
--- a/AIMS/AIMS.csproj
+++ b/AIMS/AIMS.csproj
@@ -8,6 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
   </ItemGroup>
 
 </Project>

--- a/AIMS/Data/AimsDbContext.cs
+++ b/AIMS/Data/AimsDbContext.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using AIMS.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace AIMS.Data;
+
+public partial class AimsDbContext : DbContext
+{
+    public AimsDbContext()
+    {
+    }
+
+    public AimsDbContext(DbContextOptions<AimsDbContext> options)
+        : base(options)
+    {
+    }
+
+    public virtual DbSet<Hardware> Hardwares { get; set; }
+
+    public virtual DbSet<Software> Softwares { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+#warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see https://go.microsoft.com/fwlink/?LinkId=723263.
+        => optionsBuilder.UseSqlServer("Connection String"); // Replace "Connection String" with your connection string. Will put format in discord.
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Hardware>(entity =>
+        {
+            entity.HasKey(e => e.AssetTag).HasName("PK__Hardware__89F276AACC2EBD54");
+
+            entity.ToTable("Hardware");
+
+            entity.HasIndex(e => e.SerialNumber, "UQ__Hardware__048A000838FBE506").IsUnique();
+
+            entity.Property(e => e.AssetName).HasMaxLength(255);
+            entity.Property(e => e.AssetType).HasMaxLength(255);
+            entity.Property(e => e.Manufacturer).HasMaxLength(255);
+            entity.Property(e => e.Model).HasMaxLength(255);
+            entity.Property(e => e.SerialNumber).HasMaxLength(255);
+            entity.Property(e => e.Status).HasMaxLength(255);
+        });
+
+        modelBuilder.Entity<Software>(entity =>
+        {
+            entity.HasKey(e => e.SoftwareId).HasName("PK__Software__25EDB8DC7B909065");
+
+            entity.ToTable("Software");
+
+            entity.HasIndex(e => e.SoftwareLicenseKey, "UQ__Software__953EDCAE2A3AE925").IsUnique();
+
+            entity.Property(e => e.SoftwareId).HasColumnName("SoftwareID");
+            entity.Property(e => e.SoftwareCost).HasColumnType("decimal(10, 2)");
+            entity.Property(e => e.SoftwareDeploymentLocation).HasMaxLength(255);
+            entity.Property(e => e.SoftwareLicenseKey).HasMaxLength(255);
+            entity.Property(e => e.SoftwareName).HasMaxLength(255);
+            entity.Property(e => e.SoftwareType).HasMaxLength(255);
+            entity.Property(e => e.SoftwareVersion).HasMaxLength(255);
+        });
+
+        OnModelCreatingPartial(modelBuilder);
+    }
+
+    partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+}

--- a/AIMS/Models/Hardware.cs
+++ b/AIMS/Models/Hardware.cs
@@ -1,30 +1,25 @@
-
-using Microsoft.EntityFrameworkCore; //team needs to get entity framework packages
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace AIMS.Models;
 
-//Base class for Hardware without functionality. Subclasses underneath to show inheritance example.
-//Interacts with the db through AssetContext.cs in the Data folder.
-
-public class Hardware
+public partial class Hardware
 {
-    public int Id { get; set; }
-    public int TagNumber { get; set; }
-    public string? Status { get; set; }
-    public string? Type { get; set; }
-    public string? AssignedTo { get; set; }
-}
+    public int AssetTag { get; set; }
 
-// Inherits from Hardware
-public class Laptop : Hardware
-{
-    public bool HasTouchScreen { get; set; }
-}
+    public string AssetName { get; set; } = null!;
 
-// Inherits from Hardware
-public class Desktop :  Hardware
-{
-    public int MonitorsAssigned {get; set;}
+    public string AssetType { get; set; } = null!;
+
+    public string Status { get; set; } = null!;
+
+    public string Manufacturer { get; set; } = null!;
+
+    public string Model { get; set; } = null!;
+
+    public string SerialNumber { get; set; } = null!;
+
+    public DateOnly WarrantyExpiration { get; set; }
+
+    public DateOnly PurchaseDate { get; set; }
 }

--- a/AIMS/Models/Software.cs
+++ b/AIMS/Models/Software.cs
@@ -1,17 +1,25 @@
-//using Microsoft.EntityFrameworkCore;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace AIMS.Models;
 
-public class Software
+public partial class Software
 {
-    public int Id {get; set;}
-    public int LicenseKey { get; set; }
-    public int SoftwareName { get; set; }
-    public string? Status { get; set; }
-    public string? Version { get; set; }
-    public DateTime? PurchaseDate { get; set; }
-    public DateTime? ExpireDate { get; set; }
-}
+    public int SoftwareId { get; set; }
 
+    public string SoftwareName { get; set; } = null!;
+
+    public string SoftwareType { get; set; } = null!;
+
+    public string SoftwareVersion { get; set; } = null!;
+
+    public string SoftwareDeploymentLocation { get; set; } = null!;
+
+    public string SoftwareLicenseKey { get; set; } = null!;
+
+    public DateOnly? SoftwareLicenseExpiration { get; set; }
+
+    public long SoftwareUsageData { get; set; }
+
+    public decimal SoftwareCost { get; set; }
+}


### PR DESCRIPTION
- Created AIMSDB on my local server, then CREATE TABLE for hardware and software in SQL to apply schema files. 
- Added EF dependencies for development. "Design" dependency can be taken out when we are done with development.
- Pulled in Hardware, Software, and AimsDbContext using the command below. 

Used Command -- dotnet ef dbcontext scaffold "Server=localhost,1433;Database=AIMSDB;User Id=sa;Password=StrongP@ssword!;Encrypt=False;" Microsoft.EntityFrameworkCore.SqlServer -o Models --context-dir Data --context AimsDbContext -f

- Above command only needs to be run once to create files. 
- If changes need to be made to classes we can migrate back to SQL db easily.