### PR TITLE
Fixed PNG image issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AIMS - Asset Inventory Management System
 
-![AIMS Logo](./Images/AIMSLOGO.PNG)
+![AIMS Logo](./Images/AIMSLOGO.png)
 
 ## Project Overview
 
@@ -152,7 +152,7 @@ bash
 
 This is what the home screen will look like:
 
-![AIMS Homepage](./Images/Homepage.PNG)
+![AIMS Homepage](./Images/Homepage.png)
 
 ## Design
 


### PR DESCRIPTION
PNG images for the logo and homepage were giving 404 errors because I had the .png path in uppercase instead of in lowercase. The ERD image loads correctly, because of the correct png path:  **"./Images/ERDImage.png".** 

The other two image paths have been corrected and should work as they should. I should have caught this, my apologies for the inconvenience.